### PR TITLE
bugfix

### DIFF
--- a/pocsuite3/lib/core/revision.py
+++ b/pocsuite3/lib/core/revision.py
@@ -7,7 +7,7 @@ def stdout_encode(data):
     """
     Cross-linked function
     """
-    pass
+    return data
 
 
 def get_revision_number():


### PR DESCRIPTION
修复stdout_encode()函数直接pass返回为None获取不到hash