### PR TITLE
修复 console 模式下的一处 bug。use poc1->use poc2->use poc1 使用的是poc2的脚本

### DIFF
--- a/pocsuite3/lib/core/register.py
+++ b/pocsuite3/lib/core/register.py
@@ -101,6 +101,7 @@ def load_string_to_module(code_string, fullname=None):
 def register_poc(poc_class):
     module = poc_class.__module__.split('.')[0]
     if module in kb.registered_pocs:
+        kb.current_poc = kb.registered_pocs[module]
         return
 
     kb.registered_pocs[module] = poc_class()


### PR DESCRIPTION
修复前
```
Pocsuite3 > use pocs/ecshop_rce
Pocsuite3 (pocs/ecshop_rce) > use pocs/drupalgeddon2
Pocsuite3 (pocs/drupalgeddon2) > use pocs/ecshop_rce
Pocsuite3 (pocs/ecshop_rce) > show info

name                 Drupal core Remote Code Execution
version              1.0
author               ['seebug']
vulDate              2018-03-08
createDate           2018-04-12
updateDate           2018-04-13
references           ['https://www.seebug.org/vuldb/ssvid-97207']
appName              Drupal
vulType              Romote Code Execution
desc
```
修复后
```
Pocsuite3 (pocs/ecshop_rce) > use pocs/ecshop_rce
Pocsuite3 (pocs/ecshop_rce) > use pocs/drupalgeddon2
Pocsuite3 (pocs/drupalgeddon2) > use pocs/ecshop_rce
Pocsuite3 (pocs/ecshop_rce) > show info

name                 Ecshop 2.x/3.x Remote Code Execution
version              3.0
author               ['seebug']
vulDate              2018-06-14
createDate           2018-06-14
updateDate           2018-06-14
references           ['https://www.seebug.org/vuldb/ssvid-97343']
appName              ECSHOP
appVersion           2.x,3.x
vulType              Romote Code Execution
desc                 近日，Ecshop爆出全版本SQL注入及任意代码执行漏洞，受影响的版本有：Ecshop 2.x,Ecshop 3.x-3.6.0
```