### PR TITLE
Bugfix invalid client

### DIFF
--- a/pocsuite3/modules/listener/reverse_tcp.py
+++ b/pocsuite3/modules/listener/reverse_tcp.py
@@ -243,14 +243,19 @@ def print_cmd_help():
     data_to_stdout(msg)
 
 
-def handle_listener_connection_for_console():
-    while True:
+def handle_listener_connection_for_console(wait_time=3,try_count=3):
         cmd = "select 0"
         client = get_client(cmd)
         if client is not None:
             f = send_shell_commands_for_console(client)
             if f:
-                break
+                return
+
+        if try_count > 0:
+            time.sleep(wait_time)
+            data_to_stdout("connect err remaining number of retries %s times\n"%(try_count))
+            try_count -= 1
+            return handle_listener_connection_for_console(wait_time=wait_time,try_count=try_count)
 
 
 def handle_listener_connection():


### PR DESCRIPTION
console 模式下 使用 shell 模式如果 target 填写有误。使用 shell 命令会出现 Invalid Client 死循环
可以按照以下方式复现

use pocs/thinkphp_rce2
set  target http://xx.xx.xx.xx:8001/
set lhost xx.xx.xx.xx
shell
部分数据已经做脱敏处理
修复前
Invalid Client
Invalid Client
Invalid Client
Invalid Client
.
.
.
修复后
Invalid Client
connect err remaining number of retries 3 times
Invalid Client
connect err remaining number of retries 2 times
Invalid Client
connect err remaining number of retries 1 times
Invalid Client