### PR TITLE
解决build_request()的type=dns时，verify_request()无法验证的问题

### DIFF
--- a/pocsuite3/modules/ceye/__init__.py
+++ b/pocsuite3/modules/ceye/__init__.py
@@ -1,6 +1,7 @@
 import getpass
 import json
 import time
+import re
 from configparser import ConfigParser
 
 from pocsuite3.lib.core.data import logger
@@ -168,7 +169,7 @@ class CEye(object):
         if type == "request":
             url = "http://{}.{}/{}{}{}".format(ranstr, domain, ranstr, value, ranstr)
         elif type == "dns":
-            url = domain
+            url = "{}{}{}.{}".format(ranstr, re.sub("\W", "", value), ranstr, domain)
         return {"url": url, "flag": ranstr}
 
     def getsubdomain(self):


### PR DESCRIPTION
Ceye模块中，当build_request的type=dns时，verify_request()方法  无法获取成功记录。看了一下代码，type=dns的时候，实际上只返回了最基本的子域名，没有添加用于标识的子字符串，所以做了一下处理。
解决build_request()的type=dns时，verify_request()无法验证的问题。