### PR TITLE
修复自定义cookie异常

### DIFF
--- a/pocsuite3/lib/core/option.py
+++ b/pocsuite3/lib/core/option.py
@@ -87,7 +87,10 @@ def _set_http_referer():
 
 def _set_http_cookie():
     if conf.cookie:
-        conf.http_headers[HTTP_HEADER.COOKIE] = conf.cookie
+        if isinstance(conf.cookie, dict):
+            conf.http_headers[HTTP_HEADER.COOKIE] = '; '.join(map(lambda x: '='.join(x), conf.cookie.items()))
+        else:
+            conf.http_headers[HTTP_HEADER.COOKIE] = conf.cookie
 
 
 def _set_http_host():


### PR DESCRIPTION
修复设置`conf.http_headers`时未将`conf.cookie`转换为字符串，导致requests检查请求头抛出异常的问题。详情见 #85 