### PR TITLE
修复 Shodan 调用 api 错误，增加 Fofa 接口

### DIFF
--- a/pocsuite3/api/__init__.py
+++ b/pocsuite3/api/__init__.py
@@ -19,6 +19,7 @@ from pocsuite3.modules.listener import REVERSE_PAYLOAD
 from pocsuite3.modules.seebug import Seebug
 from pocsuite3.modules.zoomeye import ZoomEye
 from pocsuite3.modules.shodan import Shodan
+from pocsuite3.modules.fofa import Fofa
 from pocsuite3.modules.censys import Censys
 from pocsuite3.modules.spider import crawl
 from pocsuite3.modules.httpserver import PHTTPServer
@@ -31,7 +32,7 @@ __all__ = (
     'PLUGIN_TYPE', 'POCBase', 'Output', 'AttribDict', 'POC_CATEGORY',
     'register_poc', 'conf', 'kb', 'logger', 'paths', 'DEFAULT_LISTENER_PORT', 'load_file_to_module',
     'load_string_to_module', 'single_time_warn_message', 'CEye', 'Seebug',
-    'ZoomEye', 'Shodan', 'PHTTPServer', 'REVERSE_PAYLOAD', 'get_listener_ip', 'get_listener_port',
+    'ZoomEye', 'Shodan','Fofa','Censys', 'PHTTPServer', 'REVERSE_PAYLOAD', 'get_listener_ip', 'get_listener_port',
     'get_results', 'init_pocsuite', 'start_pocsuite', 'get_poc_options', 'crawl',
     'OSShellcodes', 'WebShell', 'OptDict', 'OptIP', 'OptPort', 'OptBool', 'OptInteger', 'OptFloat', 'OptString', \
     'OptItems', 'OptDict', 'get_middle_text', 'generate_shellcode_list', 'random_str')

--- a/pocsuite3/lib/core/option.py
+++ b/pocsuite3/lib/core/option.py
@@ -211,7 +211,7 @@ def _set_multiple_targets():
 
     if conf.dork:
         # enable plugin 'target_from_zoomeye' by default
-        if 'target_from_shodan' not in conf.plugins:
+        if 'target_from_shodan' not in conf.plugins and 'target_from_fofa' not in conf.plugins:
             conf.plugins.append('target_from_zoomeye')
 
     if conf.dork_zoomeye:
@@ -223,6 +223,8 @@ def _set_multiple_targets():
     if conf.dork_censys:
         conf.plugins.append('target_from_censys')
 
+    if conf.dork_fofa:
+        conf.plugins.append('target_from_fofa')
 
 def _set_task_queue():
     if kb.registered_pocs and kb.targets:
@@ -485,11 +487,14 @@ def _set_conf_attributes():
     conf.login_user = None
     conf.login_pass = None
     conf.shodan_token = None
+    conf.fofa_user = None
+    conf.fofa_token = None
     conf.censys_uid = None
     conf.censys_secret = None
     conf.dork = None
     conf.dork_zoomeye = None
     conf.dork_shodan = None
+    conf.dork_fofa = None
     conf.dork_censys = None
     conf.max_page = 1
     conf.search_type = 'host'

--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -219,7 +219,8 @@ class POCBase(object):
         except BaseException as e:
             self.expt = (ERROR_TYPE_ID.OTHER, e)
             logger.error("PoC has raised a exception")
-            logger.exception(e)
+            logger.error(str(e))
+            # logger.exception(e)
             output = Output(self)
 
         return output

--- a/pocsuite3/lib/core/settings.py
+++ b/pocsuite3/lib/core/settings.py
@@ -90,7 +90,7 @@ OS_ARCH = machine()
 # Cmd line parse whitelist
 CMD_PARSE_WHITELIST = ['version', 'update', 'url', 'file', 'verify', 'attack', 'shell', 'cookie', 'host', 'referer',
                        'user-agent', 'random-agent', 'proxy', 'proxy-cred', 'timeout', 'retry', 'delay', 'headers',
-                       'login-user', 'login-pass', 'dork', 'max-page', 'search-type',
-                       'vul-keyword', 'ssv-id', 'lhost', 'lport', 'plugins', 'pocs-path', 'threads', 'batch',
-                       'requires', 'quiet', 'poc', 'verbose', 'mode', 'api', 'connect_back_host', 'connect_back_port',
-                       'ppt']
+                       'login-user', 'login-pass', 'dork', 'dork-shodan', 'dork-censys', 'dork-zoomeye', 'dork-fofa',
+                       'max-page', 'search-type', 'shodan-token', 'fofa-user', 'fofa-token', 'vul-keyword', 'ssv-id',
+                       'lhost', 'lport', 'plugins', 'pocs-path', 'threads', 'batch', 'requires', 'quiet', 'poc',
+                       'verbose', 'mode', 'api', 'connect_back_host', 'connect_back_port', 'ppt']

--- a/pocsuite3/lib/parse/cmd.py
+++ b/pocsuite3/lib/parse/cmd.py
@@ -68,6 +68,8 @@ def cmd_line_parser(argv=None):
         group.add_argument("--login-user", dest="login_user", help="Telnet404 login user")
         group.add_argument("--login-pass", dest="login_pass", help="Telnet404 login password")
         group.add_argument("--shodan-token", dest="shodan_token", help="Shodan token")
+        group.add_argument("--fofa-user", dest="fofa_user", help="fofa user")
+        group.add_argument("--fofa-token", dest="fofa_token", help="fofa token")
         group.add_argument("--censys-uid", dest="censys_uid", help="Censys uid")
         group.add_argument("--censys-secret", dest="censys_secret", help="Censys secret")
         # Modules options
@@ -80,6 +82,8 @@ def cmd_line_parser(argv=None):
                              help="Shodan dork used for search.")
         modules.add_argument("--dork-censys", dest="dork_censys", action="store", default=None,
                              help="Censys dork used for search.")
+        modules.add_argument("--dork-fofa", dest="dork_fofa", action="store", default=None,
+                             help="Fofa dork used for search.")
         modules.add_argument("--max-page", dest="max_page", type=int, default=1,
                              help="Max page used in ZoomEye API(10 targets/Page).")
         modules.add_argument("--search-type", dest="search_type", action="store", default='host',
@@ -122,8 +126,8 @@ def cmd_line_parser(argv=None):
                     diy.add_argument(line)
 
         args = parser.parse_args()
-        if not any((args.url, args.url_file, args.update_all, args.plugins, args.dork, args.configFile,
-                    args.show_version)):
+        if not any((args.url, args.url_file, args.update_all, args.plugins, args.dork, args.dork_shodan, args.dork_fofa,
+                    args.dork_censys, args.dork_zoomeye, args.configFile, args.show_version)):
             err_msg = "missing a mandatory option (-u, --url-file, --update). "
             err_msg += "Use -h for basic and -hh for advanced help\n"
             parser.error(err_msg)

--- a/pocsuite3/modules/fofa/__init__.py
+++ b/pocsuite3/modules/fofa/__init__.py
@@ -1,0 +1,97 @@
+import urllib
+import getpass
+from base64 import b64encode
+from configparser import ConfigParser
+from pocsuite3.lib.core.data import logger
+from pocsuite3.lib.core.data import paths
+from pocsuite3.lib.request import requests
+
+
+class Fofa():
+    def __init__(self, conf_path=paths.POCSUITE_RC_PATH, user=None, token=None):
+        self.headers = None
+        self.credits = 0
+        self.conf_path = conf_path
+
+        if self.conf_path:
+            self.parser = ConfigParser()
+            self.parser.read(self.conf_path)
+            try:
+                self.token = self.parser.get("Fofa", 'token')
+                self.user = self.parser.get("Fofa", 'user')
+            except Exception:
+                pass
+
+        if token or user:
+            self.user = user
+            self.token = token
+        self.check_token()
+
+    def token_is_available(self):
+        if self.token and self.user:
+            try:
+                resp = requests.get(
+                    'https://fofa.so/api/v1/info/my?email={user}&key={token}'.format(user=self.user, token=self.token))
+                if resp and resp.status_code == 200 and "username" in resp.json():
+                    return True
+            except Exception as ex:
+                logger.error(str(ex))
+        return False
+
+    def check_token(self):
+        if self.token_is_available():
+            return True
+        else:
+
+            user = input("Fofa API user:")
+            new_token = getpass.getpass("Fofa API  token:")
+            self.token = new_token
+            self.user = user
+            if self.token_is_available():
+                self.write_conf()
+                return True
+            else:
+                logger.error("The Fofa api token is incorrect. "
+                             "Please enter the correct api token.")
+                self.check_token()
+
+    def write_conf(self):
+        if not self.parser.has_section("Fofa"):
+            self.parser.add_section("Fofa")
+        try:
+            self.parser.set("Fofa", "Token", self.token)
+            self.parser.set("Fofa", "User", self.user)
+            self.parser.write(open(self.conf_path, "w"))
+        except Exception as ex:
+            logger.error(str(ex))
+
+    def search(self, dork, pages=1, resource='ip,port'):
+        if resource == 'host':
+            resource = 'ip,port'
+        else:
+            resource="web"
+        search_result = set()
+        try:
+            for page in range(1, pages + 1):
+                url = "https://fofa.so/api/v1/search/all?email={user}&key={token}&qbase64={dork}&fields={resource}&page={page}".format(
+                    user=self.user, token=self.token, dork=b64encode(dork.encode()).decode(), resource=resource, page=page)
+                resp = requests.get(url,timeout=80)
+                if resp and resp.status_code == 200 and "results" in resp.json():
+                    content = resp.json()
+                    for match in content['results']:
+                        if resource == "ip,port":
+                            search_result.add("%s:%s"%(match[0],match[1]))
+                        else:
+                            if not  match.startswith("https://"):
+                                search_result.add("http://"+match)
+                else:
+                    logger.error("[PLUGIN] Fofa:{}".format(resp.text))
+        except Exception as ex:
+            logger.error(str(ex))
+        return search_result
+
+
+if __name__ == "__main__":
+    fa = Fofa()
+    z = fa.search('body="thinkphp"')
+    print(z)

--- a/pocsuite3/modules/shodan/__init__.py
+++ b/pocsuite3/modules/shodan/__init__.py
@@ -20,9 +20,9 @@ class Shodan():
             except Exception:
                 pass
 
-        self.token = token
         if token:
-            self.write_conf()
+            self.token = token
+        self.check_token()
 
     def token_is_available(self):
         if self.token:

--- a/pocsuite3/plugins/target_from_fofa.py
+++ b/pocsuite3/plugins/target_from_fofa.py
@@ -1,0 +1,44 @@
+from pocsuite3.api import PluginBase
+from pocsuite3.api import PLUGIN_TYPE
+from pocsuite3.api import logger
+from pocsuite3.api import conf
+from pocsuite3.api import Fofa
+from pocsuite3.api import register_plugin
+from pocsuite3.api import kb
+from pocsuite3.lib.core.exception import PocsuitePluginDorkException
+
+
+class TargetFromFofa(PluginBase):
+    category = PLUGIN_TYPE.TARGETS
+
+    def init_fofa_api(self):
+        self.fofa = Fofa(user=conf.fofa_user,token=conf.fofa_token)
+
+    def init(self):
+        self.init_fofa_api()
+        dork = None
+        if conf.dork_fofa:
+            dork = conf.dork_fofa
+        else:
+            dork = conf.dork
+        if not dork:
+            msg = "Need to set up dork (please --dork or --dork-fofa)"
+            raise PocsuitePluginDorkException(msg)
+
+        if kb.comparison:
+            kb.comparison.add_dork("Fofa", dork)
+        info_msg = "[PLUGIN] try fetch targets from Fofa with dork: {0}".format(dork)
+        logger.info(info_msg)
+        targets = self.fofa.search(dork, conf.max_page, resource=conf.search_type)
+        count = 0
+        if targets:
+            for target in targets:
+                if kb.comparison:
+                    kb.comparison.add_ip(target, "Fofa")
+                if self.add_target(target):
+                    count += 1
+
+        info_msg = "[PLUGIN] get {0} target(s) from Fofa".format(count)
+        logger.info(info_msg)
+
+register_plugin(TargetFromFofa)


### PR DESCRIPTION
1. 修复 Shodan token 无法从配置文件中读取
2. 修复命令行无法使用  --dork_fofa 调用，只可以使用 --plugins target_from_shodan 调用
3. 增加 Fofa api 调用接口