### PR TITLE
Add paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests == 2.22.0
 PySocks == 1.7.1
 requests-toolbelt == 0.9.1
 urllib3 == 1.25.6
+paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests == 2.22.0
 PySocks == 1.7.1
 requests-toolbelt == 0.9.1
-urllib3 == 1.25.6
 paramiko


### PR DESCRIPTION
it's a [requirement](https://github.com/knownsec/pocsuite3/blob/0f68c1cef3804c5d43be6cfd11c2298f3d77f0ad/pocsuite3/pocs/ssh_burst.py#L12) thus it should be installed when the `pip` runs.

Proper fix for https://github.com/knownsec/pocsuite3/issues/106