### PR TITLE
Remove whitespaces

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests == 2.22.0
-PySocks == 1.7.1
-requests-toolbelt == 0.9.1
-urllib3 == 1.25.6
+requests==2.22.0
+PySocks==1.7.1
+requests-toolbelt==0.9.1
+urllib3==1.25.6


### PR DESCRIPTION
Remove whitespaces to avoid parsing issue by Python helpers (`setuptools`, `twine` and `wheel`).