### PR TITLE
fix(core): Rare race condition in makedirs with parallel processes

### DIFF
--- a/pocsuite3/lib/core/option.py
+++ b/pocsuite3/lib/core/option.py
@@ -464,10 +464,16 @@ def _adjust_logging_formatter():
 
 def _create_directory():
     if not os.path.isdir(paths.POCSUITE_OUTPUT_PATH):
-        os.makedirs(paths.POCSUITE_OUTPUT_PATH)
+        try:
+            os.makedirs(paths.POCSUITE_OUTPUT_PATH)
+        except FileExistsError:
+            pass
 
     if not os.path.isdir(paths.POCSUITE_TMP_PATH):
-        os.makedirs(paths.POCSUITE_TMP_PATH)
+        try:
+            os.makedirs(paths.POCSUITE_TMP_PATH)
+        except FileExistsError:
+            pass
 
     if not os.path.isfile(paths.POCSUITE_RC_PATH):
         open(paths.POCSUITE_RC_PATH, 'a').close()


### PR DESCRIPTION
  
This PR fix the error below: 

```
File "/usr/local/lib/python3.7/dist-packages/pocsuite3-1.6.4-py3.7.egg/pocsuite3/lib/core/option.py", line 653, in init
    _create_directory()
  File "/usr/local/lib/python3.7/dist-packages/pocsuite3-1.6.4-py3.7.egg/pocsuite3/lib/core/option.py", line 467, in _create_directory
    os.makedirs(paths.POCSUITE_OUTPUT_PATH)
  File "/usr/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/root/.pocsuite/output'

[*] shutting down at 04:42:54
```