### PR TITLE
解决导出写出HTML UTF-8编码异常

### DIFF
--- a/pocsuite3/plugins/html_report.py
+++ b/pocsuite3/plugins/html_report.py
@@ -148,7 +148,7 @@ class HtmlExport:
         self.html.main.close()
         self._writer_footer()
 
-        with open(self.filename, 'w') as f:
+        with open(self.filename, 'w', encoding='utf-8') as f:
             for x in self.html.content:
                 try:
                     f.write("{0}\n".format(x))


### PR DESCRIPTION
导出HTML乱码 查看后发现少写了encoding