### PR TITLE
给poc执行完后添加扩展结果

### DIFF
--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -166,7 +166,7 @@ class POCBase(object):
 
         return output
 
-    def execute(self, target, headers=None, params=None, mode='verify', verbose=True):
+    def execute(self, target, headers=None, params=None, mode='verify', verbose=True, ext_result=None):
         self.target = target
         self.url = parse_target_url(target) if self.current_protocol == POC_CATEGORY.PROTOCOL.HTTP else self.build_url()
         self.headers = headers
@@ -223,7 +223,7 @@ class POCBase(object):
             logger.error(str(traceback.format_exc()))
             # logger.exception(e)
             output = Output(self)
-
+        output.ext_result = ext_result
         return output
 
     # def _shell(self):
@@ -263,6 +263,7 @@ class Output(object):
     def __init__(self, poc=None):
         self.error_msg = tuple()
         self.result = {}
+        self.ext_result = {}
         self.status = OUTPUT_STATUS.FAILED
         if poc:
             self.url = poc.url

--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -170,10 +170,8 @@ class POCBase(object):
         self.target = target
         self.url = parse_target_url(target) if self.current_protocol == POC_CATEGORY.PROTOCOL.HTTP else self.build_url()
         self.headers = headers
-        if isinstance(params, dict):
+        if isinstance(params, dict) or isinstance(params, str):
             self.params = params
-        elif isinstance(params, str):
-            self.params = str_to_dict(params)
         else:
             self.params = {}
         self.mode = mode
@@ -228,8 +226,7 @@ class POCBase(object):
             logger.error(str(traceback.format_exc()))
             # logger.exception(e)
             output = Output(self)
-        if 'ext_result' in self.params:
-            output.ext_result = self.params['ext_result']
+        output.params = self.params
         return output
 
     # def _shell(self):
@@ -269,7 +266,7 @@ class Output(object):
     def __init__(self, poc=None):
         self.error_msg = tuple()
         self.result = {}
-        self.ext_result = {}
+        self.params = {}
         self.status = OUTPUT_STATUS.FAILED
         if poc:
             self.url = poc.url

--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -166,11 +166,11 @@ class POCBase(object):
 
         return output
 
-    def execute(self, target, headers=None, params=None, mode='verify', verbose=True, ext_result=None):
+    def execute(self, target, headers=None, params=None, mode='verify', verbose=True):
         self.target = target
         self.url = parse_target_url(target) if self.current_protocol == POC_CATEGORY.PROTOCOL.HTTP else self.build_url()
         self.headers = headers
-        self.params = str_to_dict(params) if params else {}
+        self.params = params if isinstance(params, dict) else {}
         self.mode = mode
         self.verbose = verbose
         self.expt = (0, 'None')
@@ -223,7 +223,8 @@ class POCBase(object):
             logger.error(str(traceback.format_exc()))
             # logger.exception(e)
             output = Output(self)
-        output.ext_result = ext_result
+        if 'ext_result' in self.params:
+            output.ext_result = self.params['ext_result']
         return output
 
     # def _shell(self):

--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -170,7 +170,12 @@ class POCBase(object):
         self.target = target
         self.url = parse_target_url(target) if self.current_protocol == POC_CATEGORY.PROTOCOL.HTTP else self.build_url()
         self.headers = headers
-        self.params = params if isinstance(params, dict) else {}
+        if isinstance(params, dict):
+            self.params = params
+        elif isinstance(params, str):
+            self.params = str_to_dict(params)
+        else:
+            self.params = {}
         self.mode = mode
         self.verbose = verbose
         self.expt = (0, 'None')


### PR DESCRIPTION
我在其他项目集成了pocsuite3，使用协程执行验证poc，我希望在协程执行那完调用callback函数后可以在结果中添加其他信息，但我看到execute方法只能传target，所以添加了扩展结果选项。
```python
poc.execute(target, ext_result={"Text": "TEXT"})
```
效果：
```json
{
    "error_msg": "None",
    "result": {
        "VerifyInfo": {
            "URL": "/?s=index/\\think\\Container/invokefunction",
            "Postdata": {
                "function": "call_user_func_array",
                "vars[0]": "phpinfo",
                "vars[1][]": "-1"
            }
        }
    },
    "ext_result": {
        "Text": "TEXT"
    },
    "status": 1,
    "url": "http://127.0.0.1:8088",
    "mode": "verify",
    "vul_id": "97715",
    "name": "ThinkPHP 5.x (v5.0.23及v5.1.31以下版本) 远程命令执行漏洞利用（GetShell）",
    "app_name": "ThinkPHP",
    "app_version": "thinkphp5.1.31"
}
```