### PR TITLE
Remove host validate

### DIFF
--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -43,14 +43,14 @@ class POCBase(object):
             self.global_options["proxy"] = OptString("", "Use a proxy to connect to the target URL")
             self.global_options["timeout"] = OptInteger(30, "Seconds to wait before timeout connection (default 30)")
         else:
-            self.global_options["rhost"] = OptIP('', require=True)
+            self.global_options["rhost"] = OptString('', require=True)
             self.global_options["rport"] = OptPort('', require=True)
             self.global_options["ssl"] = OptBool(default=False)
 
         # payload options for exploit
         self.payload_options = OrderedDict()
         if hasattr(self, "_shell"):
-            self.payload_options["lhost"] = OptIP('', "Connect back ip", require=True)
+            self.payload_options["lhost"] = OptString('', "Connect back ip", require=True)
             self.payload_options["lport"] = OptPort(10086, "Connect back port")
 
         self.options = OrderedDict()


### PR DESCRIPTION
当我用示例的poc测试域名目标时，抛出校验错误。
应该去掉 rhost 和 lhost 的 ip 限制。
https://github.com/knownsec/pocsuite3/blob/master/pocsuite3/pocs/ftp_burst.py
```
pocsuite -r ftp_burst.py -u test.example.com
[*] starting at 11:38:59

[11:38:59] [INFO] loading PoC script 'ftp_burst.py'
[11:38:59] [INFO] pocsusite got a total of 1 tasks
[11:38:59] [INFO] running poc:'FTP 弱密码' target 'test.example.com'
[11:38:59] [ERROR] Poc:'FTP 弱密码' PocsuiteValidationException:Invalid address. Provided address is not valid IPv4 or IPv6 address.
```