### PR TITLE
fix(): httpserver module 100% cpu usage

### DIFF
--- a/pocsuite3/modules/httpserver/__init__.py
+++ b/pocsuite3/modules/httpserver/__init__.py
@@ -152,6 +152,7 @@ class PHTTPServer(threading.Thread, metaclass=PHTTPSingleton):
     def run(self):
         try:
             while self.__running.is_set():
+                time.sleep(1)
                 self.__flag.wait()
                 if not self.server_started:
                     self.httpd = self.httpserver((self.bind_ip, self.bind_port), self.requestHandler)


### PR DESCRIPTION
Using while(true) loop to get the state of thread, which causes 100% cpu usage.

<img width="1438" alt="verify" src="https://user-images.githubusercontent.com/17541483/115845628-9d1b8780-a453-11eb-9805-b3bd25b04eef.png">


```
#!/usr/bin/env python3
# -*- coding:utf-8 -*-

import time
from pocsuite3.modules.httpserver import PHTTPServer
from pocsuite3.lib.core.common import get_host_ip
from http.server import BaseHTTPRequestHandler


class RequestHandler(BaseHTTPRequestHandler):

    def do_GET(self):
        status = 404
        count = 0

        global ip_to_str
        path_str = self.path.strip('/').strip()
        if path_str:
            ip_to_str[path_str] = True
        self.send_response(status)
        self.send_header('Content-Type', 'text/html')
        self.send_header("Content-Length", "{}".format(count))
        self.end_headers()


http_port = '8000'
hi = get_host_ip()
httpd = PHTTPServer(bind_port=http_port, requestHandler=RequestHandler)
httpd.start(daemon=True)
http_url = '{}://{}:{}'.format(httpd.scheme, hi, httpd.bind_port)

time.sleep(1000)
```