### PR TITLE
Add quake dork for pocsuite3

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -201,6 +201,17 @@ $ python cli.py --dork 'port:6379' --vul-keyword 'redis' --max-page 2
  $ python3 cli.py -r pocs/check_http_status.py --dork-fofa 'body="thinkphp"' --search-type web  --thread 10
  ```
 
+**--dork-quake DORK**
+
+ If you are a [**Quake**](quake) user, The API is a cool and hackable interface. ex:
+
+ Search web server thinkphp with  `app:"ThinkPHP"` keyword.
+
+
+ ```
+ $ python3 cli.py -r pocs/check_http_status.py --dork-quake 'app:"ThinkPHP"' --thread 10
+ ```
+
 **--dork-b64**
 
  In order to solve the problem of escaping, use --dork-b64 to tell the program that you are passing in base64 encoded dork.

--- a/pocsuite3/api/__init__.py
+++ b/pocsuite3/api/__init__.py
@@ -33,7 +33,7 @@ __all__ = (
     'PLUGIN_TYPE', 'POCBase', 'Output', 'AttribDict', 'POC_CATEGORY', 'VUL_TYPE',
     'register_poc', 'conf', 'kb', 'logger', 'paths', 'DEFAULT_LISTENER_PORT', 'load_file_to_module',
     'load_string_to_module', 'single_time_warn_message', 'CEye', 'Seebug',
-    'ZoomEye', 'Shodan', 'Fofa', 'Censys', 'PHTTPServer', 'REVERSE_PAYLOAD', 'get_listener_ip', 'get_listener_port',
+    'ZoomEye', 'Shodan', 'Fofa', 'Quake', 'Censys', 'PHTTPServer', 'REVERSE_PAYLOAD', 'get_listener_ip', 'get_listener_port','get_listener_port',
     'get_results', 'init_pocsuite', 'start_pocsuite', 'get_poc_options', 'crawl',
     'OSShellcodes', 'WebShell', 'OptDict', 'OptIP', 'OptPort', 'OptBool', 'OptInteger', 'OptFloat', 'OptString',
     'OptItems', 'OptDict', 'get_middle_text', 'generate_shellcode_list', 'random_str', 'encoder_bash_payload',

--- a/pocsuite3/lib/core/option.py
+++ b/pocsuite3/lib/core/option.py
@@ -225,7 +225,7 @@ def _set_multiple_targets():
 
     if conf.dork:
         # enable plugin 'target_from_zoomeye' by default
-        if 'target_from_shodan' not in conf.plugins and 'target_from_fofa' not in conf.plugins:
+        if 'target_from_shodan' not in conf.plugins and 'target_from_fofa' not in conf.plugins and 'target_from_quake' not in conf.plugins:
             conf.plugins.append('target_from_zoomeye')
 
     if conf.dork_zoomeye:
@@ -240,6 +240,8 @@ def _set_multiple_targets():
     if conf.dork_fofa:
         conf.plugins.append('target_from_fofa')
 
+    if conf.dork_quake:
+        conf.plugins.append('target_from_quake')
 
 def _set_task_queue():
     if kb.registered_pocs and kb.targets:
@@ -515,12 +517,14 @@ def _set_conf_attributes():
     conf.shodan_token = None
     conf.fofa_user = None
     conf.fofa_token = None
+    conf.quake_token = None
     conf.censys_uid = None
     conf.censys_secret = None
     conf.dork = None
     conf.dork_zoomeye = None
     conf.dork_shodan = None
     conf.dork_fofa = None
+    conf.dork_quake = None
     conf.dork_censys = None
     conf.dork_b64 = False
     conf.max_page = 1

--- a/pocsuite3/lib/core/settings.py
+++ b/pocsuite3/lib/core/settings.py
@@ -90,8 +90,8 @@ OS_ARCH = machine()
 # Cmd line parse whitelist
 CMD_PARSE_WHITELIST = ['version', 'update', 'url', 'file', 'verify', 'attack', 'shell', 'cookie', 'host', 'referer',
                        'user-agent', 'random-agent', 'proxy', 'proxy-cred', 'timeout', 'retry', 'delay', 'headers',
-                       'login-user', 'login-pass', 'dork', 'dork-shodan', 'dork-censys', 'dork-zoomeye', 'dork-fofa',
-                       'max-page', 'search-type', 'shodan-token', 'fofa-user', 'fofa-token', 'vul-keyword', 'ssv-id',
+                       'login-user', 'login-pass', 'dork', 'dork-shodan', 'dork-censys', 'dork-zoomeye', 'dork-fofa','dork-quake',
+                       'max-page', 'search-type', 'shodan-token', 'fofa-user', 'fofa-token', 'quake-token','vul-keyword', 'ssv-id',
                        'lhost', 'lport', 'plugins', 'pocs-path', 'threads', 'batch', 'requires', 'quiet', 'poc',
                        'verbose', 'mode', 'api', 'connect_back_host', 'connect_back_port', 'ppt', 'help', 'pcap',
                        'rule','rule-req','rule-filename','dork-b64']

--- a/pocsuite3/lib/parse/cmd.py
+++ b/pocsuite3/lib/parse/cmd.py
@@ -70,10 +70,11 @@ def cmd_line_parser(argv=None):
         group.add_argument("--shodan-token", dest="shodan_token", help="Shodan token")
         group.add_argument("--fofa-user", dest="fofa_user", help="fofa user")
         group.add_argument("--fofa-token", dest="fofa_token", help="fofa token")
+        group.add_argument("--quake-token", dest="quake_token", help="quake token")
         group.add_argument("--censys-uid", dest="censys_uid", help="Censys uid")
         group.add_argument("--censys-secret", dest="censys_secret", help="Censys secret")
         # Modules options
-        modules = parser.add_argument_group("Modules", "Modules(Seebug、Zoomeye、CEye、Fofa Listener) options")
+        modules = parser.add_argument_group("Modules", "Modules(Seebug、Zoomeye、CEye、Fofa、Quake Listener) options")
         modules.add_argument("--dork", dest="dork", action="store", default=None,
                              help="Zoomeye dork used for search.")
         modules.add_argument("--dork-zoomeye", dest="dork_zoomeye", action="store", default=None,
@@ -84,6 +85,8 @@ def cmd_line_parser(argv=None):
                              help="Censys dork used for search.")
         modules.add_argument("--dork-fofa", dest="dork_fofa", action="store", default=None,
                              help="Fofa dork used for search.")
+        modules.add_argument("--dork-quake", dest="dork_quake", action="store", default=None,
+                             help="Quake dork used for search.")
         modules.add_argument("--max-page", dest="max_page", type=int, default=1,
                              help="Max page used in ZoomEye API(10 targets/Page).")
         modules.add_argument("--search-type", dest="search_type", action="store", default='host',
@@ -136,7 +139,7 @@ def cmd_line_parser(argv=None):
                     diy.add_argument(line)
 
         args = parser.parse_args()
-        if not any((args.url, args.url_file, args.update_all, args.plugins, args.dork, args.dork_shodan, args.dork_fofa,
+        if not any((args.url, args.url_file, args.update_all, args.plugins, args.dork, args.dork_shodan, args.dork_fofa, args.dork_quake,
                     args.dork_censys, args.dork_zoomeye, args.configFile, args.show_version)) and not args.rule and not args.rule_req:
             err_msg = "missing a mandatory option (-u, --url-file, --update). "
             err_msg += "Use -h for basic and -hh for advanced help\n"

--- a/pocsuite3/modules/quake/__init__.py
+++ b/pocsuite3/modules/quake/__init__.py
@@ -1,0 +1,89 @@
+import getpass
+from configparser import ConfigParser
+from pocsuite3.lib.core.data import logger
+from pocsuite3.lib.core.data import paths
+from pocsuite3.lib.request import requests
+
+
+class Quake():
+    def __init__(self, conf_path=paths.POCSUITE_RC_PATH, token=None):
+        self.headers = None
+        self.credits = 0
+        self.conf_path = conf_path
+
+        if self.conf_path:
+            self.parser = ConfigParser()
+            self.parser.read(self.conf_path)
+            try:
+                self.token = self.parser.get("Quake", 'token')
+            except Exception:
+                pass
+
+        if token:
+            self.token = token
+        self.check_token()
+
+    def token_is_available(self):
+        if self.token:
+            try:
+                headers = {"X-QuakeToken": self.token,
+                           "Content-Type": "application/json"}
+                resp = requests.get(
+                    'https://quake.360.cn/api/v3/user/info', headers=headers)
+                if resp and resp.status_code == 200 and resp.json()['code'] == 0:
+                    return True
+            except Exception as ex:
+                logger.error(str(ex))
+        return False
+
+    def check_token(self):
+        if self.token_is_available():
+            return True
+        else:
+            new_token = getpass.getpass("Quake API token:")
+            self.token = new_token
+            if self.token_is_available():
+                self.write_conf()
+                return True
+            else:
+                logger.error("The Quake api token is incorrect. "
+                             "Please enter the correct api token.")
+                self.check_token()
+
+    def write_conf(self):
+        if not self.parser.has_section("Quake"):
+            self.parser.add_section("Quake")
+        try:
+            self.parser.set("Quake", "Token", self.token)
+            self.parser.write(open(self.conf_path, "w"))
+        except Exception as ex:
+            logger.error(str(ex))
+
+    def search(self, dork, pages=2):
+        search_result = set()
+        headers = {"X-QuakeToken": self.token,
+                   "Content-Type": "application/json"}
+        data = {"query": dork, "size": 10,
+                "ignore_cache": "false", "start": 1}
+        try:
+            for page in range(1, pages + 1):
+                data['start'] = page
+                url = "https://quake.360.cn/api/v3/search/quake_service"
+                resp = requests.post(
+                    url, json=data, headers=headers, timeout=80)
+                if resp and resp.status_code == 200 and resp.json()['code'] == 0:
+                    content = resp.json()
+                    for match in content['data']:
+                        search_result.add("%s:%s" %
+                                          (match['ip'], match['port']))
+                else:
+                    logger.error("[PLUGIN] Quake:{}".format(resp.text))
+        except Exception as ex:
+            logger.error(str(ex))
+        return search_result
+
+
+if __name__ == "__main__":
+    qk = Quake(token="")
+    z = qk.search('app:"F5_BIG-IP"')
+    print(z)

--- a/pocsuite3/plugins/target_from_quake.py
+++ b/pocsuite3/plugins/target_from_quake.py
@@ -1,0 +1,49 @@
+from pocsuite3.api import PluginBase
+from pocsuite3.api import PLUGIN_TYPE
+from pocsuite3.api import logger
+from pocsuite3.api import conf
+from pocsuite3.api import Quake
+from pocsuite3.api import register_plugin
+from pocsuite3.api import kb
+from pocsuite3.lib.core.exception import PocsuitePluginDorkException
+
+
+class TargetFromQuake(PluginBase):
+    category = PLUGIN_TYPE.TARGETS
+
+    def init_quake_api(self):
+        self.quake = Quake(token=conf.quake_token)
+
+    def init(self):
+        self.init_quake_api()
+        dork = None
+        if conf.dork_quake:
+            dork = conf.dork_quake
+        else:
+            dork = conf.dork
+        if not dork:
+            msg = "Need to set up dork (please --dork or --dork-quake)"
+            raise PocsuitePluginDorkException(msg)
+        if conf.dork_b64:
+            import base64
+            dork = str(base64.b64decode(dork), encoding="utf-8")
+
+        if kb.comparison:
+            kb.comparison.add_dork("Quake", dork)
+        info_msg = "[PLUGIN] try fetch targets from Quake with dork: {0}".format(
+            dork)
+        logger.info(info_msg)
+        targets = self.quake.search(dork, conf.max_page)
+        count = 0
+        if targets:
+            for target in targets:
+                if kb.comparison:
+                    kb.comparison.add_ip(target, "Quake")
+                if self.add_target(target):
+                    count += 1
+
+        info_msg = "[PLUGIN] get {0} target(s) from Quake".format(count)
+        logger.info(info_msg)
+
+
+register_plugin(TargetFromQuake)


### PR DESCRIPTION
quake 搜索引擎目前也比较常用了，所以为pocsuite3增加了这样一个dork，兼容之前的base64编码dork输入的特性，使用方式于其他dork无差别

useage:
```
pocsuite -r get_target.py --dork-quake '(app:"F5_BIG-IP")' --thread 10 --quake-token '**********'

,------.                        ,--. ,--.       ,----.   {1.7.3-5e3562a}                                                                                         
|  .--. ',---. ,---.,---.,--.,--`--,-'  '-.,---.'.-.  |                                                                                                          
|  '--' | .-. | .--(  .-'|  ||  ,--'-.  .-| .-. : .' <                                                                                                           
|  | --'' '-' \ `--.-'  `'  ''  |  | |  | \   --/'-'  |                                                                                                          
`--'     `---' `---`----' `----'`--' `--'  `----`----'   http://pocsuite.org                                                                                     
[*] starting at 09:59:55

[09:59:55] [INFO] loading PoC script '/usr/local/lib/python3.8/dist-packages/pocsuite3-1.7.3-py3.8.egg/pocsuite3/pocs/get_target.py'
[09:59:56] [INFO] [PLUGIN] try fetch targets from Quake with dork: (app:"F5_BIG-IP")
[10:00:06] [INFO] [PLUGIN] get 10 target(s) from Quake
[10:00:06] [INFO] pocsusite got a total of 10 tasks
....
```