### PR TITLE
fix(): finding a python module version gives error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,5 +247,9 @@ Cross-platform shell code generation
 
 # version 1.8.1
 -----------------
-* fix check_requires() can not handle dependent version correctly # 208
+* fix check_requires() can not handle dependent version correctly #208
 * update docs
+
+# version 1.8.2
+-----------------
+* fix finding a python module version gives error

--- a/manpages/poc-console.1
+++ b/manpages/poc-console.1
@@ -31,7 +31,7 @@ is maintained at:
 .I https://github.com/knownsec/pocsuite3/blob/master/docs/USAGE.md
 .PP
 .SH VERSION
-This manual page documents pocsuite version 1.8.1
+This manual page documents pocsuite version 1.8.2
 .SH AUTHOR
 .br
 (c) 2014-2021 by Knownsec 404 Team

--- a/manpages/pocsuite.1
+++ b/manpages/pocsuite.1
@@ -250,7 +250,7 @@ is maintained at:
 .I https://github.com/knownsec/pocsuite3/blob/master/docs/USAGE.md
 .PP
 .SH VERSION
-This manual page documents pocsuite version 1.8.1
+This manual page documents pocsuite version 1.8.2
 .SH AUTHOR
 .br
 (c) 2014-2021 by Knownsec 404 Team

--- a/pocsuite3/__init__.py
+++ b/pocsuite3/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'pocsuite'
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 __author__ = 'Knownsec Security Team'
 __author_email__ = 's1@seebug.org'
 __license__ = 'GPL 2.0'

--- a/pocsuite3/lib/core/register.py
+++ b/pocsuite3/lib/core/register.py
@@ -1,4 +1,5 @@
 import re
+import pkg_resources
 import importlib.machinery
 import importlib.util
 from importlib.abc import Loader
@@ -54,8 +55,9 @@ class PocLoader(Loader):
                         install_name = t[0]
                     if not import_name:
                         import_name = install_name
-                    m = __import__(import_name)
-                    logger.info(f'{install_name}=={m.__version__} has been installed')
+                    __import__(import_name)
+                    ver = pkg_resources.get_distribution(import_name).version
+                    logger.info(f'{install_name}=={ver} has been installed')
             except ImportError:
                 err_msg = f'{install_name} not found, try install with "python -m pip install {install_name}"'
                 logger.error(err_msg)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 setup(
     name='pocsuite3',
-    version='1.8.1',
+    version='1.8.2',
     url='http://pocsuite.org',
     description='Pocsuite is an open-sourced remote vulnerability testing framework developed by the Knownsec Security Team.',
     long_description="""\


### PR DESCRIPTION
It is not advisable to use the `__version__` attribute to find the version of a module in Python,
not every module has this attribute that can tell its version.

Refer: https://www.delftstack.com/howto/python/module-version-python/