### PR TITLE
PEP8: Avoid using bare `except:`

### DIFF
--- a/pocsuite3/lib/utils/markup.py
+++ b/pocsuite3/lib/utils/markup.py
@@ -25,7 +25,7 @@ Installation: drop markup.py somewhere into your Python path.
 try:
     basestring
     import string
-except:
+except NameError:
     # python 3
     basestring = str
     string = str


### PR DESCRIPTION
Avoid using bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.
Prefer `except Exception:`. If you’re sure what you’re doing, be explicit and write `except BaseException:`.

https://realpython.com/the-most-diabolical-python-antipattern/
https://www.python.org/dev/peps/pep-0008/

$ `python3 -c "basestring"  # --> NameError: name 'basestring' is not defined`