### PR TITLE
第三方集成时初始化提示registered_pocs属性不存在

### DIFF
--- a/pocsuite3/lib/core/datatype.py
+++ b/pocsuite3/lib/core/datatype.py
@@ -7,6 +7,7 @@ class AttribDict(OrderedDict):
     Items starting with __ or _OrderedDict__ can't be accessed as attributes.
     """
     __exclude_keys__ = set()
+    registered_pocs = dict()
 
     def __getattr__(self, name):
         if (name.startswith('__')


### PR DESCRIPTION
fix issue: https://github.com/knownsec/pocsuite3/issues/295