### PR TITLE
chore: add docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
 
   dockerhub:
     runs-on: ubuntu-latest
+    needs:
+      - pypi
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -84,8 +86,9 @@ jobs:
       env:
         GH_REF: ${{ github.ref }}
       run: |
-        docker build \
-        --tag pocsuite3/pocsuite3:v$(echo $GH_REF | sed 's:refs/tags/v::') \
+        export VERSION=$(echo $GH_REF | sed 's:refs/tags/v::')
+        docker build --build-arg version=${VERSION} \
+        --tag pocsuite3/pocsuite3:v${VERSION} \
         --tag pocsuite3/pocsuite3:latest \
         .
     - name: Login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,25 @@ jobs:
           git push origin master
         env:
           GH_REF: ${{ github.ref }}
+
+  dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      env:
+        GH_REF: ${{ github.ref }}
+      run: |
+        docker build \
+        --tag pocsuite3/pocsuite3:v$(echo $GH_REF | sed 's:refs/tags/v::') \
+        --tag pocsuite3/pocsuite3:latest \
+        .
+    - name: Login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}      
+    - name: Push
+      run: |
+        docker push -a pocsuite3/pocsuite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 MAINTAINER Knownsec 404 Team
 
+ARG version
 env DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
@@ -31,7 +32,7 @@ RUN sh -c "$(wget -O- https://raw.githubusercontent.com/13ph03nix/zsh-in-docker/
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*
 
-RUN sudo pip3 install --upgrade pip && sudo pip3 install --upgrade pocsuite3==1.9.6
+RUN sudo pip3 install --upgrade pip && sudo pip3 install --upgrade pocsuite3$([ -n "$version" ] && echo "=="${version})
 
 WORKDIR /home/pocsuite3
 CMD ["zsh"]


### PR DESCRIPTION
添加了构建/推送 Docker 镜像的 CI。

需要在 Docker Hub 中[创建一组密钥](https://hub.docker.com/settings/security)用于推送，分别作为 Secrets `DOCKER_USERNAME` 和 `DOCKER_PASSWORD`。

效果：

- [build 日志](https://github.com/0x2E/pocsuite3/runs/7382992032?check_suite_focus=true)
- [推送的镜像](https://hub.docker.com/r/rook1e404/pocsuite3/tags)