### PR TITLE
Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# version 1.9.8
+----------------
+* support full PoC search by regex keyword #312
+* set default value for PoC in POCBase #312
+* add bind/reverse shell payload #311
+* fix fofa query over multiple pages #310
+
 # version 1.9.7
 ----------------
 * improve encoding compatibility #305

--- a/manpages/poc-console.1
+++ b/manpages/poc-console.1
@@ -31,7 +31,7 @@ is maintained at:
 .I https://pocsuite.org
 .PP
 .SH VERSION
-This manual page documents pocsuite3 version 1.9.7
+This manual page documents pocsuite3 version 1.9.8
 .SH AUTHOR
 .br
 (c) 2014-present by Knownsec 404 Team

--- a/manpages/pocsuite.1
+++ b/manpages/pocsuite.1
@@ -283,7 +283,7 @@ is maintained at:
 .I https://pocsuite.org
 .PP
 .SH VERSION
-This manual page documents pocsuite3 version 1.9.7
+This manual page documents pocsuite3 version 1.9.8
 .SH AUTHOR
 .br
 (c) 2014-present by Knownsec 404 Team

--- a/pocsuite3/__init__.py
+++ b/pocsuite3/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'pocsuite3'
-__version__ = '1.9.7'
+__version__ = '1.9.8'
 __author__ = 'Knownsec 404 Team'
 __author_email__ = '404-team@knownsec.com'
 __license__ = 'GPLv2'

--- a/pocsuite3/lib/core/option.py
+++ b/pocsuite3/lib/core/option.py
@@ -351,11 +351,10 @@ def _set_pocs_modules():
 
                 for p in _pocs:
                     file_content = get_file_text(p)
-                    if 'register_poc' not in file_content:
+                    if not re.search(r'register_poc', file_content):
                         continue
                     if conf.poc_keyword:
-                        attr_field = re.search(r'vulID.*?def .*?\(', file_content, re.DOTALL)
-                        if attr_field and conf.poc_keyword.lower() not in attr_field.group().lower():
+                        if not re.search(conf.poc_keyword, file_content, re.I | re.M):
                             continue
                     info_msg = "loading PoC script '{0}'".format(p)
                     logger.info(info_msg)

--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -17,6 +17,26 @@ from pocsuite3.lib.utils import urlparse
 
 class POCBase(object):
     def __init__(self):
+        # PoC attributes
+        self.vulID = getattr(self, 'vulID', '0')
+        self.version = getattr(self, 'version', '1')
+        self.author = getattr(self, 'author', '')
+        self.vulDate = getattr(self, 'vulDate', '')
+        self.createDate = getattr(self, 'createDate', '')
+        self.updateDate = getattr(self, 'updateDate', '')
+        self.references = getattr(self, 'references', [])
+        self.name = getattr(self, 'name', '')
+        self.appPowerLink = getattr(self, 'appPowerLink', '')
+        self.appName = getattr(self, 'appName', '')
+        self.appVersion = getattr(self, 'appVersion', '')
+        self.vulType = getattr(self, 'vulType', '')
+        self.desc = getattr(self, 'desc', '')
+        self.samples = getattr(self, 'samples', [])
+        self.install_requires = getattr(self, 'install_requires', [])
+        self.dork = getattr(self, 'dork', {})
+        self.suricata_request = getattr(self, 'suricata_request', '')
+        self.suricata_response = getattr(self, 'suricata_response', '')
+        #
         self.type = None
         self.target = None
         self.headers = None

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ long_description = (
 
 setup(
     name='pocsuite3',
-    version='1.9.7',
+    version='1.9.8',
     url='https://pocsuite.org',
     description='Open-sourced remote vulnerability testing framework.',
     long_description=long_description,


### PR DESCRIPTION
1. `-k` 关键词搜索 PoC 功能支持正则，搜索范围不在局限于属性字段，而是整个 PoC。如：

```
pocsuite -k "绕过|弱密码|cgi-bin"
```

2. 在基类 POCBase 中为 PoC 的所有属性设置了默认值，写 PoC 时可以不写任何属性字段，简化 PoC 的开发。

```
from pocsuite3.api import *

class TestPOC(POCBase):
    def _verify(self):
        result = {}
        return self.parse_output(result)


register_poc(TestPOC)
```