### PR TITLE
feat: add an optional parameter "protocol_default_port" to the POC

### DIFF
--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -50,6 +50,7 @@ class POCBase(object):
         self.verbose = None
         self.expt = (0, 'None')
         self.current_protocol = getattr(self, "protocol", POC_CATEGORY.PROTOCOL.HTTP)
+        self.current_protocol_port = getattr(self, "protocol_default_port", 0)
         self.pocDesc = getattr(self, "pocDesc", "Poc的作者好懒呀！")
         self.host_ip = get_host_ip(check_private=False)
 
@@ -185,6 +186,9 @@ class POCBase(object):
             POC_CATEGORY.PROTOCOL.MEMCACHED: 11211,
             POC_CATEGORY.PROTOCOL.BACNET: 47808
         }
+
+        if self.current_protocol_port:
+            protocol_default_port_map[self.current_protocol] = self.current_protocol_port
 
         try:
             pr = urlparse(target)


### PR DESCRIPTION
在cli模式下，使用-u参数使用CIDR形式指定了一个IP段进行POC扫描时，如果POC中设置的protocol不在protocol_default_port_map中（非HTTP协议或使用了非标准端口的POC，如要对weblogic的T3协议的7001进行扫描），则默认会设置使用80端口。如果使用-p指定端口，也只是增加-p设置的端口，原来的80端口还是会扫描，在扫描数量大时，浪费时间。

同时protocol_default_port_map又没有提供相应的方法进行增加或修改。因此本提交在POC中增加了一个可选的protocol_default_port参数，用于指定该POC使用协议的默认端口。未设置时，执行逻辑与原来一致。