### PR TITLE
bugfix: v2.0.1对ipv6地址解析的问题

### DIFF
--- a/pocsuite3/lib/core/poc.py
+++ b/pocsuite3/lib/core/poc.py
@@ -209,7 +209,7 @@ class POCBase(object):
                 # adjust port
                 if not self.rport:
                     self.rport = protocol_default_port_map[self.current_protocol]
-            self.netloc = f'{self.rhost}:{self.rport}'
+            self.netloc = f'{self.rhost}:{self.rport}' if not conf.ipv6 else f'[{self.rhost}]:{self.rport}'
             pr = pr._replace(scheme=self.scheme)
             pr = pr._replace(netloc=self.netloc)
             target = pr.geturl()


### PR DESCRIPTION
没有处理ipv6的url格式，导致 http://[fe80::3a40:2e16:3436:f319]:8080/  会被处理成 http://fe80::3a40:2e16:3436:f319:8080/，导致ipv6目标的漏洞无法验证成功。